### PR TITLE
[fix] Remove SSOwat conf regen from scripts

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -47,4 +47,3 @@ then
 fi
 
 sudo service nginx reload
-sudo yunohost app ssowatconf

--- a/scripts/restore
+++ b/scripts/restore
@@ -52,4 +52,3 @@ then
 fi
 
 sudo service nginx reload
-sudo yunohost app ssowatconf

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -46,4 +46,3 @@ then
 fi
 
 sudo service nginx reload
-sudo yunohost app ssowatconf


### PR DESCRIPTION
The SSOwat configuration is already regenerated at the end of the app installation/removal/upgrade - okay I've just added it for the upgrade now, I admit...